### PR TITLE
Distinguish logical operators from other operators

### DIFF
--- a/Syntaxes/Lua.plist
+++ b/Syntaxes/Lua.plist
@@ -375,7 +375,7 @@
 			<key>match</key>
 			<string>\b(and|or|not)\b</string>
 			<key>name</key>
-			<string>keyword.operator.lua</string>
+			<string>keyword.operator.logical.lua</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
This makes syntax highlighting themes able to color the `and`/`or`/`not` keywords correctly.

For comparison, the [Ruby language bundle already does this with `keyword.operator.logical.ruby`](https://github.com/textmate/ruby.tmbundle/blob/02613b0279ca1c2df5699adbb21e11ca28021e57/Syntaxes/Ruby.plist#L1864-L1869).